### PR TITLE
Asociando argumento del programa con key de un Map

### DIFF
--- a/rometools - Parsing RSS/src/RomeTools.java
+++ b/rometools - Parsing RSS/src/RomeTools.java
@@ -1,4 +1,7 @@
-package aplicandoLibreria;
+import java.util.stream.Stream;
+import java.util.Map;
+import java.util.stream.Collectors;
+import static java.util.stream.Collectors.toMap;
 
 import java.net.URL;
 
@@ -11,16 +14,39 @@ public class RomeTools {
 
 	public static void main(String[] args) {
 		boolean ok = false;
+		/*
+                String[][] ar = new String[][] {
+                     { "elp", "http://ep00.epimg.net/rss/tags/ultimas_noticias.xml" },
+                     { "cnn", "http://rss.cnn.com/rss/edition.rss" },
+                     { "bbc", "http://feeds.bbci.co.uk/news/rss.xml" } };
+	        */	
+		// java >= 9
+		
+                Map<String, String> map = Map.of("elp","http://ep00.epimg.net/rss/tags/ultimas_noticias.xml",
+			               	         "cnn","http://rss.cnn.com/rss/edition.rss",
+                                                 "bbc","http://feeds.bbci.co.uk/news/rss.xml"); 
+		
+                // java >= 8
+               
+	       	/*Map<String, String> map = Stream.of(new String[][] {
+                     { "elp", "http://ep00.epimg.net/rss/tags/ultimas_noticias.xml" },
+                     { "bbc", "http://feeds.bbci.co.uk/news/rss.xml" },
+                     { "cnn", "http://rss.cnn.com/rss/edition.rss" }
+                }).collect(toMap(data -> data[0], data -> data[1])); */
 
 		if (args.length == 1) {
 			try {
-				URL feedURL = new URL(args[0]);
+				URL feedURL = new URL(map.get(args[0]));
 				SyndFeedInput input = new SyndFeedInput();
 				SyndFeed feed = input.build(new XmlReader(feedURL));
 
 				for (SyndEntry entry : feed.getEntries()) {
 					System.out.println("\n" + entry.getTitle());
 				}
+				/*
+				System.out.println("\n\nArray [0][1]: " + ar[0][1]);
+				System.out.println("\n\nArray [1][0]: " + ar[1][0]);
+				*/
 
 				ok = true;
 			} catch (Exception ex) {
@@ -29,7 +55,7 @@ public class RomeTools {
 			}
 		}
 		if (!ok) {
-			System.out.println("An error ocurred: the first parameter must be the URL of the feed to read.");
+			System.out.println("Usage: one argument with any of the values [ elp cnn bbc ]");
 		}
 
 	}


### PR DESCRIPTION
Hola,

Intento mostrar dos formas de inicializar un Map con tres keys cada una con el identificativo de un contenido rss, y en sus respectivos valores la URL de cada recurso.
De esta forma permitimos que el argumento a proporcionar al programa al ejecutarlo sea el identificativo de tres caracteres.

Las dos formas de inicialización de la estructura de datos Map, son de
* java >= 8
* java >= 9
Se puede *jugar* con cada una descomentando.
Si el compilador y JVM son release 8 habrá error al compilar, si has dejado descomentada la notación java9.

Es una aportación sobre otras notaciones posteriores a la que ya tú conoces.

También he visto adecuado incluir instrucciones que declaran e inicializan un array de dos dimensiones, también con la misma información del Map.

Saludos

Paulino 